### PR TITLE
Make tx push a 2 step to avoid issues

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,16 +78,13 @@ if [[ "$INPUT_GIT_FLOW" = true ]] ; then
     git diff --staged --quiet || git commit -m "Update translations" && git stash && git merge --no-edit $CURRENT_BRANCH
 
     # and let's push the merged version upstream
-    if [[ "$INPUT_PUSH_SOURCES" = true ]] && [[ "$INPUT_PUSH_TRANSLATIONS" = true ]] ; then
-        tx push -s -t --no-interactive "${common_args[@]}"
-    else
-        if [[ "$INPUT_PUSH_SOURCES" = true ]] ; then
-            tx push -s --no-interactive "${common_args[@]}"
-        fi
 
-        if [[ "$INPUT_PUSH_TRANSLATIONS" = true ]] ; then
-            tx push -t --no-interactive "${common_args[@]}"
-        fi
+    if [[ "$INPUT_PUSH_SOURCES" = true ]] ; then
+        tx push -s --no-interactive "${common_args[@]}"
+    fi
+
+    if [[ "$INPUT_PUSH_TRANSLATIONS" = true ]] ; then
+        tx push -t --no-interactive "${common_args[@]}"
     fi
 
     if [[ "$INPUT_PULL_SOURCES" = true ]] || [[ "$INPUT_PULL_TRANSLATIONS" = true ]] ; then


### PR DESCRIPTION
We have noticed that pushing the sources and translations at the same time sometimes has unpredictable consequences.

We've had more reliable results by pushing first the sources, and then the translations