### PR TITLE
Use git timestamps to pull only needed files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -83,3 +83,7 @@ inputs:
     description: 'Pushes or pulls things from transifex in parallel'
     required: false
     default: 'false'
+  use_git_timestamps:
+    description: 'Use git timestamps to only pull newest resources'
+    required: false
+    default: 'false'


### PR DESCRIPTION
Uses this new tx client functionality to only pull files that have timestamps in transifex that are newer than the most recent commit for that file