### PR TITLE
Update transifex CLI version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM python:3.7
+FROM alpine:3.17
 
 LABEL "repository"="https://github.com/sergioisidoro/github-transifex-action"
 LABEL "homepage"="https://github.com/sergioisidoro/github-transifex-action"
 LABEL "maintainer"="Sergio Isidoro <smaisidoro@gmail.com>"
 
-
-RUN pip install transifex-client
-RUN apt-get install git
+RUN apk add --no-cache bash curl git
+RUN curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
+RUN mv tx /usr/bin/
+RUN chmod +x /usr/bin/tx
 
 ADD entrypoint.sh /entrypoint.sh
-
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Transifex has deprecated its old CLI, this PR install the new CLI  into the docker image   